### PR TITLE
go sample: add more advanced sample with filters

### DIFF
--- a/go/graphql/sample/readme.md
+++ b/go/graphql/sample/readme.md
@@ -12,13 +12,13 @@ You enter the query you want on the left side, and click play!
 ## Do you have any example queries?
 ```
 {
-  users {
-    name
+  games(titleRegex: "Great"){
+    title
     runs {
-      game {
-        title
-      }
       time
+      runner {
+        name
+      }
     }
   }
 }


### PR DESCRIPTION
Previously the sample did not show how to add or use
arguments in queries. This makes that more clear for copying
elsewhere.