### PR TITLE
postman sample: add sample postman collection

### DIFF
--- a/postman/Sample Server.postman_collection.json
+++ b/postman/Sample Server.postman_collection.json
@@ -1,0 +1,181 @@
+{
+	"info": {
+		"_postman_id": "b811c88a-888c-4282-85af-e192fbec16aa",
+		"name": "Sample Server",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "List games",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"pm.test(\"Response time is less than 200ms\", function () {\r",
+							"    pm.expect(pm.response.responseTime).to.be.below(200);\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\r\n  games {\r\n    title\r\n  }\r\n}\r\n",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3030/graphql/http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"graphql",
+						"http"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "List all runs for all games",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"pm.test(\"Response time is less than 200ms\", function () {\r",
+							"    pm.expect(pm.response.responseTime).to.be.below(200);\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\r\n  games{\r\n    title\r\n    runs {\r\n      time\r\n      runner {\r\n        name\r\n      }\r\n    }\r\n  }\r\n}\r\n",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3030/graphql/http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"graphql",
+						"http"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "List all runs for certain games",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"pm.test(\"Response time is less than 200ms\", function () {\r",
+							"    pm.expect(pm.response.responseTime).to.be.below(200);\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\r\n  games(titleRegex: \"Great\"){\r\n    title\r\n    runs {\r\n      time\r\n      runner {\r\n        name\r\n      }\r\n    }\r\n  }\r\n}\r\n",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3030/graphql/http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"graphql",
+						"http"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "List fast runs",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"pm.test(\"Response time is less than 200ms\", function () {\r",
+							"    pm.expect(pm.response.responseTime).to.be.below(200);\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\r\n  runs(maxDurationMs: 1800000) {\r\n    time\r\n    runner {\r\n      name\r\n    }\r\n  }\r\n}\r\n",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3030/graphql/http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"graphql",
+						"http"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
Postman can be a useful tool for non-backend developers to
build against. We can use collections to share types of queries
frontend developers can make.

Postman collections are also generally more sharable than
screenshots from Graphiql.

Postman collections do not replace unit testing though.

---

Sample screenshots:
<img width="664" alt="postman" src="https://user-images.githubusercontent.com/13932684/125182854-7ead6880-e1c6-11eb-8eeb-27f0a18943ba.png">
<img width="392" alt="postman2" src="https://user-images.githubusercontent.com/13932684/125182869-9b49a080-e1c6-11eb-9896-3873457cdc37.png">
