### PR TITLE
.vscode: add basic go settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "go.coverOnSingleTest": true,
+    "go.coverOnSingleTestFile": true,
+    "go.testFlags": ["-v", "-race"]
+}


### PR DESCRIPTION
Test coverage is generally useful, so enable it for most test runs.

Listing the tests run and enabling race-detection is also useful
for identifying issues.