### PR TITLE
Added REST example

### DIFF
--- a/go-rest-example/api/platformRoutes.go
+++ b/go-rest-example/api/platformRoutes.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/speedrun-website/speedrun-rest/data"
+)
+
+func loadPlatformRoutes(router *mux.Router) {
+	platformRouter := router.PathPrefix("/platforms").Subrouter()
+
+	// Index
+	platformRouter.
+		Path("/").
+		HandlerFunc(getPlatforms).
+		Name("PlatformIndex").
+		Methods("GET")
+
+	// Show
+	platformRouter.
+		Path("/{name}").
+		HandlerFunc(getPlatformByName).
+		Name("PlatformShow").
+		Methods("GET")
+
+	// Create
+	platformRouter.
+		Path("/").
+		HandlerFunc(authenticatedHandler(createPlatform)).
+		Name("PlatformCreate").
+		Methods("POST")
+}
+
+func getPlatforms(w http.ResponseWriter, r *http.Request) {
+	platforms := data.GetPlatforms()
+	writeJsonResponse(w, platforms)
+}
+
+func getPlatformByName(w http.ResponseWriter, r *http.Request) {
+	platformName := mux.Vars(r)["name"]
+	platform, err := data.GetPlatformByName(platformName)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	writeJsonResponse(w, platform)
+}
+
+func createPlatform(w http.ResponseWriter, r *http.Request) {
+	var platform data.Platform
+	decoder := json.NewDecoder(r.Body)
+	decoder.Decode(&platform)
+
+	data.CreatePlatform(platform)
+
+	writeJsonResponse(w, platform)
+}

--- a/go-rest-example/api/router.go
+++ b/go-rest-example/api/router.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"github.com/gorilla/mux"
+)
+
+func LoadRouter() *mux.Router {
+	router := mux.NewRouter()
+
+	loadPlatformRoutes(router)
+	// loadGameRoutes(router)
+
+	return router
+}

--- a/go-rest-example/api/util.go
+++ b/go-rest-example/api/util.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/speedrun-website/speedrun-rest/auth"
+)
+
+type requestFunction func(w http.ResponseWriter, r *http.Request)
+
+func writeJsonResponse(w http.ResponseWriter, data interface{}) {
+	w.Header().Add("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(data)
+}
+
+func authenticatedHandler(handler requestFunction) requestFunction {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		splitAuthHeader := strings.Split(authHeader, " ")
+		if len(splitAuthHeader) < 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		apiKey := splitAuthHeader[1]
+		if !auth.VerifyAPIKey(apiKey) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		handler(w, r)
+	}
+}

--- a/go-rest-example/auth/auth.go
+++ b/go-rest-example/auth/auth.go
@@ -1,0 +1,6 @@
+package auth
+
+// FIXME lol
+func VerifyAPIKey(key string) bool {
+	return key == "apikey"
+}

--- a/go-rest-example/data/game.go
+++ b/go-rest-example/data/game.go
@@ -1,0 +1,7 @@
+package data
+
+type Game struct {
+	Name      string
+	Release   string
+	Platforms []Platform
+}

--- a/go-rest-example/data/platform.go
+++ b/go-rest-example/data/platform.go
@@ -1,0 +1,33 @@
+package data
+
+import "errors"
+
+type Platform struct {
+	Name string
+}
+
+var platforms = []Platform{
+	{Name: "PC"}, {Name: "PS5"}, {Name: "SNES"},
+}
+
+func CreatePlatform(platform Platform) {
+	platforms = append(platforms, platform)
+}
+
+func GetPlatforms() []Platform {
+	return platforms
+}
+
+func GetPlatformByName(name string) (Platform, error) {
+	var platform Platform
+	for _, p := range platforms {
+		if p.Name == name {
+			platform = p
+			break
+		}
+	}
+	if platform == (Platform{}) {
+		return Platform{}, errors.New("No platform with the specified name.")
+	}
+	return platform, nil
+}

--- a/go-rest-example/go.mod
+++ b/go-rest-example/go.mod
@@ -1,0 +1,5 @@
+module github.com/speedrun-website/speedrun-rest
+
+go 1.16
+
+require github.com/gorilla/mux v1.8.0 // indirect

--- a/go-rest-example/go.sum
+++ b/go-rest-example/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/go-rest-example/main.go
+++ b/go-rest-example/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/speedrun-website/speedrun-rest/api"
+)
+
+func main() {
+	router := api.LoadRouter()
+
+	fmt.Println("listening on 8080")
+	http.ListenAndServe(":8080", router)
+}


### PR DESCRIPTION
This is not really intended to be merged; I'm making it for visibility to get feedback. 
Even though support is on the side of GraphQL, I decided there wasn't much harm in at least writing out a REST API example for people to look at and provide feedback. I think the idea I had here that can be adopted anyway is a separate `data` package. It would allow us to give that data any interface we want, GraphQL or REST or something else esoteric if we want.