### PR TITLE
.vscode: add recommended extension list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"editorconfig.editorconfig",
+		"golang.go"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}


### PR DESCRIPTION
This will prompt users to install these extensions when they
open this workspace in vscode. This is not a required action,
but it may help users find the things they need.

---

Note: VSCode generated this, and it seems to be happy with
the comments in the json file. I am open to removing them
though if the Github UI is too dramatic about them.