### PR TITLE
editorconfig: handle Makefile and .md whitespace 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,15 @@
 root = true
 
-[*.go,Makefile]
+[*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_tailing_whitespace = false


### PR DESCRIPTION
Tabs are required for indentation in Makefiles

Trailing whitespace is significant in Markdown