### PR TITLE
Update repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# speedrun-rest
+# leaderboard-backend
 An open-source community-driven leaderboard backend for the gaming community.
 
 ## Links

--- a/app/graphql_server/main.go
+++ b/app/graphql_server/main.go
@@ -8,8 +8,8 @@ import (
 	"github.com/samsarahq/thunder/graphql/graphiql"
 	"github.com/samsarahq/thunder/graphql/introspection"
 
-	"github.com/speedrun-website/speedrun-rest/data"
-	"github.com/speedrun-website/speedrun-rest/graphql_server"
+	"github.com/speedrun-website/leaderboard-backend/data"
+	"github.com/speedrun-website/leaderboard-backend/graphql_server"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/speedrun-website/leaderboard-backend
 go 1.16
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/graphql-go/graphql v0.7.9 // indirect
@@ -13,4 +12,5 @@ require (
 	github.com/samsarahq/thunder v0.5.0
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/speedrun-website/speedrun-rest
+module github.com/speedrun-website/leaderboard-backend
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -37,8 +36,9 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/graphql_server/server.go
+++ b/graphql_server/server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/speedrun-website/speedrun-rest/data"
+	"github.com/speedrun-website/leaderboard-backend/data"
 
 	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/thunder/graphql"

--- a/graphql_server/server_test.go
+++ b/graphql_server/server_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/speedrun-website/speedrun-rest/data"
+	"github.com/speedrun-website/leaderboard-backend/data"
 
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
The repo for this project has been changed from
`speedrun-rest` to `leaderboard-backend`.

Separately: our go mod file was out of date.