### PR TITLE
github workflows: add basic CI workflow

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -1,0 +1,39 @@
+name: backend-lint
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  go-mod-tidy:
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Set up Golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    ## Run go mod tidy and then check if there was a diff. If so, fail the check.
+    - name: Check go mod tidy diff
+      run: if [ $(go mod tidy && git diff | wc -l) -gt 0 ]; then git diff && exit 1; fi
+  golangci:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          only-new-issues: false
+          skip-go-installation: true
+          skip-pkg-cache: false
+          skip-build-cache: false
+          version: latest
+          args: --enable goimports

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,21 @@
+name: backend-test
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  backend-test:
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Set up Golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Running Tests
+      run: make test

--- a/middleware/metrics_test.go
+++ b/middleware/metrics_test.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -102,7 +102,7 @@ func TestPrometheusMiddlewareAttached(t *testing.T) {
 	}
 
 	t.Log("Reading response body")
-	body, err := io.ReadAll(res.Body)
+	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		t.FailNow()
 	}

--- a/middleware/metrics_test.go
+++ b/middleware/metrics_test.go
@@ -42,9 +42,12 @@ func TestPrometheusRegisters(t *testing.T) {
 
 	t.Log("Registering Prometheus Metrics")
 
-	prometheus.Register(tR)
-	prometheus.Register(rS)
-	prometheus.Register(hD)
+	err := prometheus.Register(tR)
+	assert.NoError(err)
+	err = prometheus.Register(rS)
+	assert.NoError(err)
+	err = prometheus.Register(hD)
+	assert.NoError(err)
 
 	tR.WithLabelValues("firstLabel").Inc()
 	tR.WithLabelValues("secondLabel").Inc()


### PR DESCRIPTION
The first commit is a fix to a lint error caught by golintci.

This commit adds some basic automated workflows that trigger on every push and every PR against main branch.
It currently does three things:
 - runs all our go tests via call to `make test`. It does this test on ubuntu and macos.
 - runs `go mod tidy` and fails the job if there are any git diffs detected.
 - runs golangci-lint

Here's a run of this workflow on my own fork of the repo: https://github.com/weilianchu/leaderboard-backend/pull/1/checks

Closes https://github.com/speedrun-website/leaderboard-backend/issues/18