### PR TITLE
go middleware: simplify prometheus registration

### DIFF
--- a/app/graphql_server/main.go
+++ b/app/graphql_server/main.go
@@ -59,9 +59,6 @@ func main() {
 	router.Path("/graphql/http").Handler(graphql.HTTPHandler(schema))
 	router.PathPrefix("/graphiql/").Handler(http.StripPrefix("/graphiql/", graphiql.Handler()))
 
-	// Initialize Prometheus bindings
-	middleware.RegisterPrometheus()
-
 	// Run the server.
 	if err := http.ListenAndServe(":3030", router); err != nil {
 		log.Fatal(err)

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -10,42 +9,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 )
-
-var totalRequests = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "http_requests_total",
-		Help: "Number of get requests.",
-	},
-	[]string{"path"},
-)
-
-var responseStatus = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "response_status",
-		Help: "Status of HTTP response",
-	},
-	[]string{"status"},
-)
-
-var httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Name: "http_response_time_seconds",
-	Help: "Duration of HTTP requests.",
-}, []string{"path"})
-
-func RegisterPrometheus() {
-	if err := prometheus.Register(totalRequests); err != nil {
-		// TODO: Log properly here once we have some standard way to log.
-		fmt.Printf("error registering totalRequests counter: %s", err.Error())
-	}
-	if err := prometheus.Register(responseStatus); err != nil {
-		// TODO: Log properly here once we have some standard way to log.
-		fmt.Printf("error registering responseStatus counter: %s", err.Error())
-	}
-	if err := prometheus.Register(httpDuration); err != nil {
-		// TODO: Log properly here once we have some standard way to log.
-		fmt.Printf("error registering httpDuration histogram: %s", err.Error())
-	}
-}
 
 // PrometheusMiddleware is a middleware which produces metrics about requests.
 func PrometheusMiddleware(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {

--- a/middleware/prometheus_registrations.go
+++ b/middleware/prometheus_registrations.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	if err := prometheus.Register(totalRequests); err != nil {
+		// TODO: Log properly here once we have some standard way to log.
+		fmt.Printf("error registering totalRequests counter: %s", err.Error())
+	}
+	if err := prometheus.Register(responseStatus); err != nil {
+		// TODO: Log properly here once we have some standard way to log.
+		fmt.Printf("error registering responseStatus counter: %s", err.Error())
+	}
+	if err := prometheus.Register(httpDuration); err != nil {
+		// TODO: Log properly here once we have some standard way to log.
+		fmt.Printf("error registering httpDuration histogram: %s", err.Error())
+	}
+}
+
+var (
+	totalRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_requests_total",
+			Help: "Number of get requests.",
+		},
+		[]string{"path"},
+	)
+	responseStatus = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "response_status",
+			Help: "Status of HTTP response",
+		},
+		[]string{"status"},
+	)
+	httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "http_response_time_seconds",
+		Help: "Duration of HTTP requests.",
+	}, []string{"path"})
+)


### PR DESCRIPTION
In the long term we will likely add metrics to a wide number of
places. Standardizing how we format this code and simplifying
finding this code within a package will help us get there without
complicating the rest of the code.