### PR TITLE
go middleware: only add handler to mux once

### DIFF
--- a/middleware/mux_adapter/mux_adapter.go
+++ b/middleware/mux_adapter/mux_adapter.go
@@ -10,8 +10,8 @@ import (
 // Middleware converts a set of negroni.Handler middlewares into a mux.MiddlewareFunc.
 // This method is meant to make it easier to set up middleware in a router agnostic way.
 func Middleware(middlewares ...negroni.Handler) mux.MiddlewareFunc {
-	negroniHandler := negroni.New(middlewares...)
 	return func(next http.Handler) http.Handler {
+		negroniHandler := negroni.New(middlewares...)
 		negroniHandler.UseHandler(next)
 		return negroniHandler
 	}

--- a/middleware/mux_adapter/mux_adapter_test.go
+++ b/middleware/mux_adapter/mux_adapter_test.go
@@ -6,27 +6,39 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/negroni"
 )
 
 func TestMuxAdapterMiddleware(t *testing.T) {
-	didRun := false
+	middlewareRunCount := 0
 	testMiddleware := func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-		didRun = true
+		middlewareRunCount++
 		next(rw, r)
+	}
+
+	handlerRunCount := 0
+	testHandler := func(rw http.ResponseWriter, r *http.Request) {
+		handlerRunCount++
+		rw.WriteHeader(http.StatusOK)
 	}
 
 	router := mux.NewRouter()
 	router.Use(Middleware(negroni.HandlerFunc(testMiddleware)))
-	router.Path("/test").Handler(promhttp.Handler())
+	router.Path("/test").HandlerFunc(testHandler)
 
 	t.Log("Launching server")
 	ts := httptest.NewServer(router)
 	defer ts.Close()
+	testUrl := ts.URL + "/test"
 
-	_, err := http.Get(ts.URL + "/test")
+	_, err := http.Get(testUrl)
 	assert.NoError(t, err)
-	assert.True(t, didRun)
+	assert.Equal(t, 1, middlewareRunCount)
+	assert.Equal(t, 1, handlerRunCount)
+
+	_, err = http.Get(testUrl)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, middlewareRunCount)
+	assert.Equal(t, 2, handlerRunCount)
 }


### PR DESCRIPTION
Previously we made a shared negroni middleware which
we would keep adding the same handler to. This would
break when you made multiple requests.