### PR TITLE
main: Allow graceful shutdown of server

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,34 +1,44 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
-
-	_ "github.com/joho/godotenv/autoload"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/joho/godotenv"
 	"github.com/speedrun-website/leaderboard-backend/database"
 	"github.com/speedrun-website/leaderboard-backend/router"
 )
 
 func main() {
-	port := os.Getenv("BACKEND_PORT")
+	if err := godotenv.Load(".env"); err != nil {
+		log.Fatal(err)
+	}
 
 	if err := database.Init(); err != nil {
 		log.Fatal(err)
-		panic(err)
 	}
 
 	r := gin.Default()
-
 	router.InitRoutes(r)
-
+	port := os.Getenv("BACKEND_PORT")
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: r,
+	}
 	go func() {
-		if err := http.ListenAndServe(":"+port, r); err != nil {
-			log.Fatal(err)
-			panic(err)
+		err := srv.ListenAndServe()
+		if err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				log.Print("Server shutdown complete!")
+			} else {
+				log.Printf("Server encountered unexpected error: %s", err)
+			}
 		}
 	}()
 
@@ -36,6 +46,14 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
+	log.Println("Interrupt received. Server shutting down...")
 
-	log.Println("Shutdown Server ...")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("Server forced to shutdown: %s", err)
+	}
+
+	log.Println("Exiting")
 }


### PR DESCRIPTION
The goroutine as it was written here had no exit strategy. Since you
should never start a goroutine without knowing how it will end, added a
graceful shutdown after the interrupt signal that allows the goroutine
to properly exit before the program finishes.