### PR TITLE
go model: Remove Max Limit for Password Length

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -25,7 +25,7 @@ type UserPersonal struct {
 type UserRegister struct {
 	Username        string `json:"username" binding:"required"`
 	Email           string `json:"email" binding:"required,email"`
-	Password        string `json:"password" binding:"required,min=8,max=64"`
+	Password        string `json:"password" binding:"required,min=8"`
 	PasswordConfirm string `json:"password_confirm" binding:"eqfield=Password"`
 }
 


### PR DESCRIPTION
Closes: #63

Removes the max requirement in the JSON tag for `UserRegister.Password`.