### PR TITLE
main: Server shutdown timeout printf

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatalf("Server forced to shutdown: %s", err)
+		log.Printf("Server forced to shutdown: %s", err)
 	}
 
 	log.Println("Exiting")


### PR DESCRIPTION
Instead of doing log.Fatalf when the server is forced to shutdown, do
log.Printf so the deferred cancel function is still run on error.