### PR TITLE
database: Use err instead of casted err

### DIFF
--- a/database/gorm_user_store.go
+++ b/database/gorm_user_store.go
@@ -54,7 +54,7 @@ func (s gormUserStore) CreateUser(user model.User) error {
 			return ErrUserNotUnique
 		}
 		return UserCreationError{
-			Err: pgErr,
+			Err: err,
 		}
 	}
 


### PR DESCRIPTION
If `errors.As` fails, we would still attempt to use it as the error
wrapped in a UserCreationError. Use the uncasted `err` as the inner
error instead.